### PR TITLE
docs: restyle readme and add tech badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,30 @@
 
 # Bitcrush
 
-Turn images into crisp pixel art with selectable palettes and algorithms. This repo contains the Next.js UI only; the pixel engine will be migrated to Rust.
+[![Built with Rust](https://img.shields.io/badge/rust-000000?style=flat-square&logo=rust&logoColor=white)](https://www.rust-lang.org/)
+[![Built with Tauri](https://img.shields.io/badge/tauri-24C8DB?style=flat-square&logo=tauri&logoColor=black)](https://tauri.app/)
+[![Built with Bun](https://img.shields.io/badge/bun-000000?style=flat-square&logo=bun&logoColor=white)](https://bun.sh/)
+[![Built with TypeScript](https://img.shields.io/badge/typescript-3178C6?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+
+## Introduction
+
+Bitcrush turns images into crisp pixel art with selectable palettes and algorithms. Version **0.1.0** coming soon.
+
+## Features
+
+* Convert images into pixel art using customizable palettes and algorithms.
+* Cross-platform desktop app powered by the Tauri framework.
+* Modern frontend with Bun, Vite, and TypeScript.
+* Pixel-processing engine in Rust (migration underway).
+
+## Support
+
+Have questions or found a bug? [Open an issue](../../issues) to let us know.
+
+## Credits
+
+Bitcrush is developed and maintained by the Bitcrush contributors.
+
+## License
+
+License coming soon.


### PR DESCRIPTION
## Summary
- restyle README to mimic Aseprite style
- add Rust, Tauri, Bun, and TypeScript badges
- mention upcoming 0.1.0 release

## Testing
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68afee71db70832b87d2f5543f96b954