### PR TITLE
Expand dithering algorithms and improve Floyd-Steinberg

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,11 @@
               <option>Randomized Selective</option>
               <option>Stucki</option>
               <option>Atkinson</option>
+              <option>Jarvis-Judice-Ninke</option>
+              <option>Burkes</option>
+              <option>Sierra</option>
+              <option>Two-Row Sierra</option>
+              <option>Sierra Lite</option>
             </select>
           </div>
 

--- a/src-tauri/src/engine/dither/burkes.rs
+++ b/src-tauri/src/engine/dither/burkes.rs
@@ -1,0 +1,54 @@
+use image::Rgba;
+
+use crate::engine::color::{ciede2000, rgb_to_lab};
+use crate::engine::algorithms::RgbaImage;
+
+fn find_closest(r: u8, g: u8, b: u8, palette: &[[u8;3]]) -> [u8;3] {
+    if palette.is_empty() { return [r,g,b]; }
+    let lab = rgb_to_lab(r,g,b);
+    let mut best = palette[0];
+    let mut best_d = f32::INFINITY;
+    for [pr,pg,pb] in palette.iter().copied() {
+        let d = ciede2000(lab, rgb_to_lab(pr,pg,pb));
+        if d < best_d { best_d = d; best = [pr,pg,pb]; }
+    }
+    best
+}
+
+// Burkes diffusion, denominator 32
+pub fn apply_burkes(img: &mut RgbaImage, palette: &[[u8;3]]) {
+    if palette.is_empty() { return; }
+    let w = img.width() as i32;
+    let h = img.height() as i32;
+    let mut buf = img.clone();
+    for y in 0..h {
+        let left_to_right = (y % 2) == 0;
+        let xr: Box<dyn Iterator<Item=i32>> = if left_to_right { Box::new(0..w) } else { Box::new((0..w).rev()) };
+        for x in xr {
+            let p = buf.get_pixel(x as u32, y as u32).0;
+            let (r,g,b,a) = (p[0], p[1], p[2], p[3]);
+            let chosen = find_closest(r,g,b,palette);
+            img.put_pixel(x as u32, y as u32, Rgba([chosen[0],chosen[1],chosen[2],a]));
+            let er = r as i16 - chosen[0] as i16;
+            let eg = g as i16 - chosen[1] as i16;
+            let eb = b as i16 - chosen[2] as i16;
+            let scatter = |dx:i32,dy:i32,num:i16,den:i16,buf:&mut RgbaImage| {
+                let nx=x+dx; let ny=y+dy;
+                if nx>=0 && nx<w && ny>=0 && ny<h {
+                    let mut q=buf.get_pixel(nx as u32, ny as u32).0;
+                    let add=|c:u8,e:i16|->u8{ (c as i16 + (e*num)/den).clamp(0,255) as u8 };
+                    q[0]=add(q[0],er); q[1]=add(q[1],eg); q[2]=add(q[2],eb);
+                    buf.put_pixel(nx as u32, ny as u32, Rgba(q));
+                }
+            };
+            if left_to_right {
+                scatter(1,0,8,32,&mut buf); scatter(2,0,4,32,&mut buf);
+                scatter(-2,1,2,32,&mut buf); scatter(-1,1,4,32,&mut buf); scatter(0,1,8,32,&mut buf); scatter(1,1,4,32,&mut buf); scatter(2,1,2,32,&mut buf);
+            } else {
+                scatter(-1,0,8,32,&mut buf); scatter(-2,0,4,32,&mut buf);
+                scatter(2,1,2,32,&mut buf); scatter(1,1,4,32,&mut buf); scatter(0,1,8,32,&mut buf); scatter(-1,1,4,32,&mut buf); scatter(-2,1,2,32,&mut buf);
+            }
+        }
+    }
+}
+

--- a/src-tauri/src/engine/dither/floyd_steinberg.rs
+++ b/src-tauri/src/engine/dither/floyd_steinberg.rs
@@ -25,12 +25,17 @@ impl Algorithm for FloydSteinberg {
         let h = img.height() as i32;
         let mut buf = img.clone();
         for y in 0..h {
-            for x in 0..w {
+            let left_to_right = (y % 2) == 0;
+            let xr: Box<dyn Iterator<Item = i32>> = if left_to_right {
+                Box::new(0..w)
+            } else {
+                Box::new((0..w).rev())
+            };
+            for x in xr {
                 let p = buf.get_pixel(x as u32, y as u32).0;
-                let (r,g,b,a) = (p[0], p[1], p[2], p[3]);
-                let chosen = find_closest_palette_color(r,g,b,palette);
-                let idx = (x as u32, y as u32);
-                img.put_pixel(idx.0, idx.1, Rgba([chosen[0], chosen[1], chosen[2], a]));
+                let (r, g, b, a) = (p[0], p[1], p[2], p[3]);
+                let chosen = find_closest_palette_color(r, g, b, palette);
+                img.put_pixel(x as u32, y as u32, Rgba([chosen[0], chosen[1], chosen[2], a]));
                 let err_r = r as i16 - chosen[0] as i16;
                 let err_g = g as i16 - chosen[1] as i16;
                 let err_b = b as i16 - chosen[2] as i16;
@@ -49,10 +54,17 @@ impl Algorithm for FloydSteinberg {
                     }
                 };
 
-                distribute(x+1, y    , 7, 16, &mut buf);
-                distribute(x-1, y+1  , 3, 16, &mut buf);
-                distribute(x  , y+1  , 5, 16, &mut buf);
-                distribute(x+1, y+1  , 1, 16, &mut buf);
+                if left_to_right {
+                    distribute(x + 1, y, 7, 16, &mut buf);
+                    distribute(x - 1, y + 1, 3, 16, &mut buf);
+                    distribute(x, y + 1, 5, 16, &mut buf);
+                    distribute(x + 1, y + 1, 1, 16, &mut buf);
+                } else {
+                    distribute(x - 1, y, 7, 16, &mut buf);
+                    distribute(x + 1, y + 1, 3, 16, &mut buf);
+                    distribute(x, y + 1, 5, 16, &mut buf);
+                    distribute(x - 1, y + 1, 1, 16, &mut buf);
+                }
             }
         }
     }

--- a/src-tauri/src/engine/dither/jarvis_judice_ninke.rs
+++ b/src-tauri/src/engine/dither/jarvis_judice_ninke.rs
@@ -1,0 +1,56 @@
+use image::Rgba;
+
+use crate::engine::color::{ciede2000, rgb_to_lab};
+use crate::engine::algorithms::RgbaImage;
+
+fn find_closest(r: u8, g: u8, b: u8, palette: &[[u8;3]]) -> [u8;3] {
+    if palette.is_empty() { return [r,g,b]; }
+    let lab = rgb_to_lab(r,g,b);
+    let mut best = palette[0];
+    let mut best_d = f32::INFINITY;
+    for [pr,pg,pb] in palette.iter().copied() {
+        let d = ciede2000(lab, rgb_to_lab(pr,pg,pb));
+        if d < best_d { best_d = d; best = [pr,pg,pb]; }
+    }
+    best
+}
+
+// Jarvis, Judice & Ninke diffusion, denominator 48
+pub fn apply_jjn(img: &mut RgbaImage, palette: &[[u8;3]]) {
+    if palette.is_empty() { return; }
+    let w = img.width() as i32;
+    let h = img.height() as i32;
+    let mut buf = img.clone();
+    for y in 0..h {
+        let left_to_right = (y % 2) == 0;
+        let xr: Box<dyn Iterator<Item=i32>> = if left_to_right { Box::new(0..w) } else { Box::new((0..w).rev()) };
+        for x in xr {
+            let p = buf.get_pixel(x as u32, y as u32).0;
+            let (r,g,b,a) = (p[0], p[1], p[2], p[3]);
+            let chosen = find_closest(r,g,b,palette);
+            img.put_pixel(x as u32, y as u32, Rgba([chosen[0],chosen[1],chosen[2],a]));
+            let er = r as i16 - chosen[0] as i16;
+            let eg = g as i16 - chosen[1] as i16;
+            let eb = b as i16 - chosen[2] as i16;
+            let scatter = |dx:i32,dy:i32,num:i16,den:i16,buf:&mut RgbaImage| {
+                let nx=x+dx; let ny=y+dy;
+                if nx>=0 && nx<w && ny>=0 && ny<h {
+                    let mut q=buf.get_pixel(nx as u32, ny as u32).0;
+                    let add=|c:u8,e:i16|->u8{ (c as i16 + (e*num)/den).clamp(0,255) as u8 };
+                    q[0]=add(q[0],er); q[1]=add(q[1],eg); q[2]=add(q[2],eb);
+                    buf.put_pixel(nx as u32, ny as u32, Rgba(q));
+                }
+            };
+            if left_to_right {
+                scatter(1,0,7,48,&mut buf); scatter(2,0,5,48,&mut buf);
+                scatter(-2,1,3,48,&mut buf); scatter(-1,1,5,48,&mut buf); scatter(0,1,7,48,&mut buf); scatter(1,1,5,48,&mut buf); scatter(2,1,3,48,&mut buf);
+                scatter(-2,2,1,48,&mut buf); scatter(-1,2,3,48,&mut buf); scatter(0,2,5,48,&mut buf); scatter(1,2,3,48,&mut buf); scatter(2,2,1,48,&mut buf);
+            } else {
+                scatter(-1,0,7,48,&mut buf); scatter(-2,0,5,48,&mut buf);
+                scatter(2,1,3,48,&mut buf); scatter(1,1,5,48,&mut buf); scatter(0,1,7,48,&mut buf); scatter(-1,1,5,48,&mut buf); scatter(-2,1,3,48,&mut buf);
+                scatter(2,2,1,48,&mut buf); scatter(1,2,3,48,&mut buf); scatter(0,2,5,48,&mut buf); scatter(-1,2,3,48,&mut buf); scatter(-2,2,1,48,&mut buf);
+            }
+        }
+    }
+}
+

--- a/src-tauri/src/engine/dither/mod.rs
+++ b/src-tauri/src/engine/dither/mod.rs
@@ -7,4 +7,7 @@ pub mod dual_color;
 pub mod randomized_selective;
 pub mod stucki;
 pub mod atkinson;
+pub mod jarvis_judice_ninke;
+pub mod burkes;
+pub mod sierra;
 

--- a/src-tauri/src/engine/dither/sierra.rs
+++ b/src-tauri/src/engine/dither/sierra.rs
@@ -1,0 +1,104 @@
+use image::Rgba;
+
+use crate::engine::color::{ciede2000, rgb_to_lab};
+use crate::engine::algorithms::RgbaImage;
+
+fn nearest(r:u8,g:u8,b:u8,palette:&[[u8;3]])->[u8;3]{
+    if palette.is_empty(){return[r,g,b];}
+    let lab=rgb_to_lab(r,g,b); let mut best=palette[0]; let mut best_d=f32::INFINITY;
+    for [pr,pg,pb] in palette.iter().copied(){
+        let d=ciede2000(lab,rgb_to_lab(pr,pg,pb));
+        if d<best_d{best_d=d;best=[pr,pg,pb];}
+    }
+    best
+}
+
+// Sierra-3 diffusion (three-row Sierra), denominator 32
+pub fn apply_sierra(img:&mut RgbaImage,palette:&[[u8;3]]){
+    if palette.is_empty(){return;}
+    let w=img.width() as i32; let h=img.height() as i32; let mut buf=img.clone();
+    for y in 0..h{
+        let ltr=(y%2)==0; let xr:Box<dyn Iterator<Item=i32>>=if ltr{Box::new(0..w)}else{Box::new((0..w).rev())};
+        for x in xr{
+            let p=buf.get_pixel(x as u32,y as u32).0; let(r,g,b,a)=(p[0],p[1],p[2],p[3]);
+            let chosen=nearest(r,g,b,palette); img.put_pixel(x as u32,y as u32,Rgba([chosen[0],chosen[1],chosen[2],a]));
+            let er=r as i16-chosen[0] as i16; let eg=g as i16-chosen[1] as i16; let eb=b as i16-chosen[2] as i16;
+            let sc=|dx:i32,dy:i32,num:i16,den:i16,buf:&mut RgbaImage|{
+                let nx=x+dx; let ny=y+dy; if nx>=0&&nx<w&&ny>=0&&ny<h{
+                    let mut q=buf.get_pixel(nx as u32,ny as u32).0;
+                    let add=|c:u8,e:i16|->u8{(c as i16+(e*num)/den).clamp(0,255) as u8};
+                    q[0]=add(q[0],er); q[1]=add(q[1],eg); q[2]=add(q[2],eb);
+                    buf.put_pixel(nx as u32,ny as u32,Rgba(q));
+                }
+            };
+            if ltr{
+                sc(1,0,5,32,&mut buf); sc(2,0,3,32,&mut buf);
+                sc(-2,1,2,32,&mut buf); sc(-1,1,4,32,&mut buf); sc(0,1,5,32,&mut buf); sc(1,1,4,32,&mut buf); sc(2,1,2,32,&mut buf);
+                sc(-1,2,2,32,&mut buf); sc(0,2,3,32,&mut buf); sc(1,2,2,32,&mut buf);
+            }else{
+                sc(-1,0,5,32,&mut buf); sc(-2,0,3,32,&mut buf);
+                sc(2,1,2,32,&mut buf); sc(1,1,4,32,&mut buf); sc(0,1,5,32,&mut buf); sc(-1,1,4,32,&mut buf); sc(-2,1,2,32,&mut buf);
+                sc(1,2,2,32,&mut buf); sc(0,2,3,32,&mut buf); sc(-1,2,2,32,&mut buf);
+            }
+        }
+    }
+}
+
+// Two-row Sierra diffusion, denominator 16
+pub fn apply_two_row_sierra(img:&mut RgbaImage,palette:&[[u8;3]]){
+    if palette.is_empty(){return;}
+    let w=img.width() as i32; let h=img.height() as i32; let mut buf=img.clone();
+    for y in 0..h{
+        let ltr=(y%2)==0; let xr:Box<dyn Iterator<Item=i32>>=if ltr{Box::new(0..w)}else{Box::new((0..w).rev())};
+        for x in xr{
+            let p=buf.get_pixel(x as u32,y as u32).0; let(r,g,b,a)=(p[0],p[1],p[2],p[3]);
+            let chosen=nearest(r,g,b,palette); img.put_pixel(x as u32,y as u32,Rgba([chosen[0],chosen[1],chosen[2],a]));
+            let er=r as i16-chosen[0] as i16; let eg=g as i16-chosen[1] as i16; let eb=b as i16-chosen[2] as i16;
+            let sc=|dx:i32,dy:i32,num:i16,den:i16,buf:&mut RgbaImage|{
+                let nx=x+dx; let ny=y+dy; if nx>=0&&nx<w&&ny>=0&&ny<h{
+                    let mut q=buf.get_pixel(nx as u32,ny as u32).0;
+                    let add=|c:u8,e:i16|->u8{(c as i16+(e*num)/den).clamp(0,255) as u8};
+                    q[0]=add(q[0],er); q[1]=add(q[1],eg); q[2]=add(q[2],eb);
+                    buf.put_pixel(nx as u32,ny as u32,Rgba(q));
+                }
+            };
+            if ltr{
+                sc(1,0,4,16,&mut buf); sc(2,0,3,16,&mut buf);
+                sc(-2,1,1,16,&mut buf); sc(-1,1,2,16,&mut buf); sc(0,1,3,16,&mut buf); sc(1,1,2,16,&mut buf); sc(2,1,1,16,&mut buf);
+            }else{
+                sc(-1,0,4,16,&mut buf); sc(-2,0,3,16,&mut buf);
+                sc(2,1,1,16,&mut buf); sc(1,1,2,16,&mut buf); sc(0,1,3,16,&mut buf); sc(-1,1,2,16,&mut buf); sc(-2,1,1,16,&mut buf);
+            }
+        }
+    }
+}
+
+// Sierra Lite diffusion, denominator 4
+pub fn apply_sierra_lite(img:&mut RgbaImage,palette:&[[u8;3]]){
+    if palette.is_empty(){return;}
+    let w=img.width() as i32; let h=img.height() as i32; let mut buf=img.clone();
+    for y in 0..h{
+        let ltr=(y%2)==0; let xr:Box<dyn Iterator<Item=i32>>=if ltr{Box::new(0..w)}else{Box::new((0..w).rev())};
+        for x in xr{
+            let p=buf.get_pixel(x as u32,y as u32).0; let(r,g,b,a)=(p[0],p[1],p[2],p[3]);
+            let chosen=nearest(r,g,b,palette); img.put_pixel(x as u32,y as u32,Rgba([chosen[0],chosen[1],chosen[2],a]));
+            let er=r as i16-chosen[0] as i16; let eg=g as i16-chosen[1] as i16; let eb=b as i16-chosen[2] as i16;
+            let sc=|dx:i32,dy:i32,num:i16,den:i16,buf:&mut RgbaImage|{
+                let nx=x+dx; let ny=y+dy; if nx>=0&&nx<w&&ny>=0&&ny<h{
+                    let mut q=buf.get_pixel(nx as u32,ny as u32).0;
+                    let add=|c:u8,e:i16|->u8{(c as i16+(e*num)/den).clamp(0,255) as u8};
+                    q[0]=add(q[0],er); q[1]=add(q[1],eg); q[2]=add(q[2],eb);
+                    buf.put_pixel(nx as u32,ny as u32,Rgba(q));
+                }
+            };
+            if ltr{
+                sc(1,0,2,4,&mut buf);
+                sc(-1,1,1,4,&mut buf); sc(0,1,1,4,&mut buf);
+            }else{
+                sc(-1,0,2,4,&mut buf);
+                sc(1,1,1,4,&mut buf); sc(0,1,1,4,&mut buf);
+            }
+        }
+    }
+}
+

--- a/src-tauri/src/engine/pipeline.rs
+++ b/src-tauri/src/engine/pipeline.rs
@@ -15,6 +15,9 @@ use super::dither::{
     randomized_selective::apply_randomized_selective,
     stucki::apply_stucki,
     atkinson::apply_atkinson,
+    jarvis_judice_ninke::apply_jjn,
+    burkes::apply_burkes,
+    sierra::{apply_sierra, apply_two_row_sierra, apply_sierra_lite},
 };
 use super::palettes::get_palette_by_name;
 
@@ -148,6 +151,11 @@ pub fn render_preview_png(req: RenderRequest) -> Result<String, EngineError> {
         "Randomized Selective" => apply_randomized_selective(&mut grid, &pal_slice, 30.0),
         "Stucki" => apply_stucki(&mut grid, &pal_slice),
         "Atkinson" => apply_atkinson(&mut grid, &pal_slice),
+        "Jarvis-Judice-Ninke" | "Jarvis, Judice, and Ninke" => apply_jjn(&mut grid, &pal_slice),
+        "Burkes" => apply_burkes(&mut grid, &pal_slice),
+        "Sierra" => apply_sierra(&mut grid, &pal_slice),
+        "Two-Row Sierra" => apply_two_row_sierra(&mut grid, &pal_slice),
+        "Sierra Lite" => apply_sierra_lite(&mut grid, &pal_slice),
         _ => algo.process(&mut grid, &pal_slice),
     }
     let target = req.display_size.unwrap_or(560);
@@ -175,6 +183,11 @@ pub fn render_base_png(req: RenderRequest) -> Result<String, EngineError> {
         "Randomized Selective" => apply_randomized_selective(&mut grid, &pal_slice, 30.0),
         "Stucki" => apply_stucki(&mut grid, &pal_slice),
         "Atkinson" => apply_atkinson(&mut grid, &pal_slice),
+        "Jarvis-Judice-Ninke" | "Jarvis, Judice, and Ninke" => apply_jjn(&mut grid, &pal_slice),
+        "Burkes" => apply_burkes(&mut grid, &pal_slice),
+        "Sierra" => apply_sierra(&mut grid, &pal_slice),
+        "Two-Row Sierra" => apply_two_row_sierra(&mut grid, &pal_slice),
+        "Sierra Lite" => apply_sierra_lite(&mut grid, &pal_slice),
         _ => algo.process(&mut grid, &pal_slice),
     }
     encode_png_base64(&grid)
@@ -199,6 +212,11 @@ pub fn render_preview_png_with_palette(req: RenderRequest, palette_colors: Vec<[
         "Randomized Selective" => apply_randomized_selective(&mut grid, &pal_slice, 30.0),
         "Stucki" => apply_stucki(&mut grid, &pal_slice),
         "Atkinson" => apply_atkinson(&mut grid, &pal_slice),
+        "Jarvis-Judice-Ninke" | "Jarvis, Judice, and Ninke" => apply_jjn(&mut grid, &pal_slice),
+        "Burkes" => apply_burkes(&mut grid, &pal_slice),
+        "Sierra" => apply_sierra(&mut grid, &pal_slice),
+        "Two-Row Sierra" => apply_two_row_sierra(&mut grid, &pal_slice),
+        "Sierra Lite" => apply_sierra_lite(&mut grid, &pal_slice),
         _ => algo.process(&mut grid, &pal_slice),
     }
     let target = req.display_size.unwrap_or(560);
@@ -224,6 +242,11 @@ pub fn render_base_png_with_palette(req: RenderRequest, palette_colors: Vec<[u8;
         "Randomized Selective" => apply_randomized_selective(&mut grid, &pal_slice, 30.0),
         "Stucki" => apply_stucki(&mut grid, &pal_slice),
         "Atkinson" => apply_atkinson(&mut grid, &pal_slice),
+        "Jarvis-Judice-Ninke" | "Jarvis, Judice, and Ninke" => apply_jjn(&mut grid, &pal_slice),
+        "Burkes" => apply_burkes(&mut grid, &pal_slice),
+        "Sierra" => apply_sierra(&mut grid, &pal_slice),
+        "Two-Row Sierra" => apply_two_row_sierra(&mut grid, &pal_slice),
+        "Sierra Lite" => apply_sierra_lite(&mut grid, &pal_slice),
         _ => algo.process(&mut grid, &pal_slice),
     }
     encode_png_base64(&grid)


### PR DESCRIPTION
## Summary
- add Jarvis-Judice-Ninke, Burkes, Sierra, Two-Row Sierra, and Sierra Lite error diffusion dithers
- switch Floyd–Steinberg to serpentine scanning to reduce artifacts
- expose new algorithms in the UI and rendering pipeline

## Testing
- `cargo test`
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_68b2b87fda98832bb905599b45bb59b0